### PR TITLE
[WIP] update to TF.NET 0.10.5

### DIFF
--- a/examples/ImageClassifier.fsx
+++ b/examples/ImageClassifier.fsx
@@ -1,6 +1,6 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
-#I "../tests/bin/Debug/net461/"
+#I "../tests/bin/Debug/net472/"
 #r "TensorFlow.FSharp.dll"
 #r "Tensorflow.NET.dll"
 #r "NumSharp.Core.dll"

--- a/examples/LinearRegression.fsx
+++ b/examples/LinearRegression.fsx
@@ -1,6 +1,6 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
-#I "../tests/bin/Debug/net461/"
+#I "../tests/bin/Debug/net472/"
 #r "TensorFlow.FSharp.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"

--- a/examples/NeuralStyleTransfer-dsl.fsx
+++ b/examples/NeuralStyleTransfer-dsl.fsx
@@ -6,9 +6,9 @@
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net461/TensorFlow.FSharp.dll"
-#r "../tests/bin/Debug/net461/Tensorflow.Net.dll"
-#r "../tests/bin/Debug/net461/NumSharp.Core.dll"
+#r "../tests/bin/Debug/net472/TensorFlow.FSharp.dll"
+#r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
+#r "../tests/bin/Debug/net472/NumSharp.Core.dll"
 //#load "shared/NPYReaderWriter.fsx"
 //#load "shared/ScriptLib.fsx"
 

--- a/examples/NeuralStyleTransfer.fsx
+++ b/examples/NeuralStyleTransfer.fsx
@@ -1,6 +1,6 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
-#I "../tests/bin/Debug/net461/"
+#I "../tests/bin/Debug/net472/"
 #r "TensorFlow.FSharp.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"

--- a/examples/TF.MNist.fsx
+++ b/examples/TF.MNist.fsx
@@ -1,6 +1,6 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
-#I "../tests/bin/Debug/net461/"
+#I "../tests/bin/Debug/net472/"
 #r "TensorFlow.FSharp.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"

--- a/examples/Torch.MNist.fsx
+++ b/examples/Torch.MNist.fsx
@@ -8,7 +8,7 @@
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#I "../tests/bin/Debug/net461/"
+#I "../tests/bin/Debug/net472/"
 #r "TorchSharp"
 #r "FSharp.AI.Tests.dll"
 

--- a/examples/dsl-live.fsx
+++ b/examples/dsl-live.fsx
@@ -2,9 +2,9 @@
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net461/TensorFlow.FSharp.dll"
-#r "../tests/bin/Debug/net461/NumSharp.Core.dll"
-#r "../tests/bin/Debug/net461/Tensorflow.Net.dll"
+#r "../tests/bin/Debug/net472/TensorFlow.FSharp.dll"
+#r "../tests/bin/Debug/net472/NumSharp.Core.dll"
+#r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
 #r "FSharp.Compiler.Interactive.Settings"
 #nowarn "49"
 

--- a/src/TensorFlow.FSharp/Tensorflow.FSharp.fsproj
+++ b/src/TensorFlow.FSharp/Tensorflow.FSharp.fsproj
@@ -13,13 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Argu" Version="5.5.0" />
+    <PackageReference Include="NumSharp" Version="0.10.5" />
     <PackageReference Include="Markeli.Half" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="NumSharp" Version="0.10.4" />
     <PackageReference Include="Ionic.Zlib.Core" Version="1.0.0" />
     <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
-    <PackageReference Include="TensorFlow.NET" Version="0.10.0-rc" />
+    <PackageReference Include="TensorFlow.NET" Version="0.10.0" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/src/TensorFlow.FSharp/Tensorflow.FSharp.fsproj
+++ b/src/TensorFlow.FSharp/Tensorflow.FSharp.fsproj
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NumSharp" Version="0.10.5" />
+    <PackageReference Include="NumSharp" Version="0.10.6" />
     <PackageReference Include="Markeli.Half" Version="1.0.0" />
     <PackageReference Include="Ionic.Zlib.Core" Version="1.0.0" />
     <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
-    <PackageReference Include="TensorFlow.NET" Version="0.10.0" />
+    <PackageReference Include="TensorFlow.NET" Version="0.10.1" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
     <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/tests/DSL.Tests.fs
+++ b/tests/DSL.Tests.fs
@@ -95,27 +95,27 @@ let ``basic checks Zero AssertShape``() =
     |> DT.toArray2D
     |> shouldEqual "wcevwo11" (array2D [ [ 0.0; 0.0 ]; [0.0; 0.0]])
 
-//[<Test>]
-//let ``basic checks diff``() = 
-//    let f x = fm { return x * x + v 4.0 * x }
-//    let df x = DT.diff f x
-//
-//    df (v 3.0)
-//    |> DT.Eval
-//    |> DT.toScalar
-//    |> shouldEqual "wcevwo12" (2.0 * 3.0 + 4.0)
-
-(*
 [<Test>]
-let ``basic checks scalar addition, multiplication, subtraction``() = 
-    let f (x: DT<_>) = 1 * x * x * 1 / 1.0 + 4 * x + 5 - 1 + 1
+let ``basic checks diff``() = 
+    let f x = fm { return x * x + v 4.0 * x }
     let df x = DT.diff f x
 
     df (v 3.0)
     |> DT.Eval
     |> DT.toScalar
     |> shouldEqual "wcevwo12" (2.0 * 3.0 + 4.0)
-*)
+
+
+// [<Test>]
+// let ``basic checks scalar addition, multiplication, subtraction``() = 
+//     let f (x: DT<_>) = 1 * x * x * 1 / 1.0 + 4 * x + 5 - 1 + 1
+//     let df x = DT.diff f x
+
+//     df (v 3.0)
+//     |> DT.Eval
+//     |> DT.toScalar
+//     |> shouldEqual "wcevwo12" (2.0 * 3.0 + 4.0)
+
 
 [<Test>]
 let ``basic checks broadcast``() = 

--- a/tests/DSL.VGGStyleTransfer.fs
+++ b/tests/DSL.VGGStyleTransfer.fs
@@ -11,9 +11,9 @@
 
 //#I __SOURCE_DIRECTORY__
 //#r "netstandard"
-//#r "../tests/bin/Debug/net461/TensorFlow.FSharp.dll"
-//#r "../tests/bin/Debug/net461/Tensorflow.Net.dll"
-//#r "../tests/bin/Debug/net461/NumSharp.Core.dll"
+//#r "../tests/bin/Debug/net472/TensorFlow.FSharp.dll"
+//#r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
+//#r "../tests/bin/Debug/net472/NumSharp.Core.dll"
 //#load "shared/NPYReaderWriter.fsx"
 //#load "shared/ScriptLib.fsx"
 

--- a/tests/FSharp.AI.Tests.fsproj
+++ b/tests/FSharp.AI.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net472</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x86;linux-x64</RuntimeIdentifiers>
     <RootNamespace>TensorFlow.FSharp.Tests</RootNamespace>
     <AssemblyName>FSharp.AI.Tests</AssemblyName>

--- a/tests/FSharp.AI.Tests.fsproj
+++ b/tests/FSharp.AI.Tests.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x86;linux-x64</RuntimeIdentifiers>
     <RootNamespace>TensorFlow.FSharp.Tests</RootNamespace>
     <AssemblyName>FSharp.AI.Tests</AssemblyName>
@@ -19,9 +19,12 @@
     <PackageReference Include="TorchSharp" Version="0.2.0-preview-27915-4" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
     <PackageReference Update="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Argu" Version="5.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
   </ItemGroup> 
 
   <ItemGroup>

--- a/tests/api-tests.fsx
+++ b/tests/api-tests.fsx
@@ -2,8 +2,8 @@
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net461/TensorFlow.FSharp.Proto.dll"
-#r "bin/Debug/net461/TensorFlow.FSharp.dll"
+#r "../tests/bin/Debug/net472/TensorFlow.FSharp.Proto.dll"
+#r "bin/Debug/net472/TensorFlow.FSharp.dll"
 #nowarn "49"
 
 //open Argu


### PR DESCRIPTION

This shouldn't be merged yet as TF.NET 0.10.5 can't be used on .NET Framework, only .NET Core

https://github.com/SciSharp/TensorFlow.NET/issues/308


