### PR TITLE
rename to FSAI

### DIFF
--- a/FSAI.sln
+++ b/FSAI.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.271
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.AI", "src\FSharp.AI\FSharp.AI.fsproj", "{2C0E5D68-1DED-4F19-8397-77B80767FC04}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSAI.Tools", "src\FSAI.Tools\FSAI.Tools.fsproj", "{2C0E5D68-1DED-4F19-8397-77B80767FC04}"
 EndProject
-Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharp.AI.Tests", "tests\FSharp.AI.Tests.fsproj", "{0F43F9C4-6696-45D5-AEB0-DBB4B24658F3}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSAI.Tools.Tests", "tests\FSAI.Tools.Tests.fsproj", "{0F43F9C4-6696-45D5-AEB0-DBB4B24658F3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Contents:
 * Live Checking Tooling for AI models
 * fsx2nb
 
+
 # FM: F# for AI Models 
 
 FM an F# eDSL for writing numeric models. Models written in FM can be passed to 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a POC that it is possible to configure F# to be suitable for authoring A
 execute them as real, full-speed TensorFlow graphs, achieving cohabitation and win-win with the TF ecosystem.
 Live trajectory execution tooling can give added correctness guarantess interactively.
 
-FM currently executes using FSharp.AI, which is why it's in this repo.
+FM currently executes using FSAI.Tools, which is why it's in this repo.
 
 The aim of FM is to support the authoring of numeric functions and AI models - including
 neural networks - in F# code. For example:
@@ -193,13 +193,13 @@ module ModelExample =
     validation learnedCoeffs
 ```
 
-More examples/tests are in [dsl-live.fsx](https://github.com/fsprojects/FSharp.AI/blob/master/examples/dsl-live.fsx).
+More examples/tests are in [dsl-live.fsx](https://github.com/fsprojects/FSAI.Tools/blob/master/examples/dsl-live.fsx).
 
 The approach scales to the complete expression of deep neural networks 
 and full computation graphs. The links below show the implementation of a common DNN sample (the samples may not
 yet run, this is wet paint):
 
-* [NeuralStyleTransfer in DSL form](https://github.com/fsprojects/FSharp.AI/blob/master/examples/NeuralStyleTransfer-dsl.fsx)
+* [NeuralStyleTransfer in DSL form](https://github.com/fsprojects/FSAI.Tools/blob/master/examples/NeuralStyleTransfer-dsl.fsx)
 
 The design is intended to allow alternative execution with Torch or DiffSharp.
 DiffSharp may be used once Tensors are available in that library.
@@ -235,7 +235,7 @@ DiffSharp may be used once Tensors are available in that library.
 
 # The TensorFlow API for F# 
 
-See `FSharp.AI`.  This API is designed in a similar way to `TensorFlowSharp`, but is implemented directly in F# and
+See `FSAI.Tools`.  This API is designed in a similar way to `TensorFlowSharp`, but is implemented directly in F# and
 contains some additional functionality.
 
 # Live Checking Tooling for AI models
@@ -273,7 +273,7 @@ LiveCheck for a DNN:
 
 3. Start the tool and edit using experimental VS instance
 
-       cd FSharp.AI\examples
+       cd FSAI.Tools\examples
        ..\..\FSharp.Compiler.PortaCode\FsLive.Cli\bin\Debug\net471\FsLive.Cli.exe --eval --writeinfo --watch --vshack --livechecksonly  --define:LIVECHECK dsl-live.fsx
 
        devenv.exe /rootsuffix RoslynDev
@@ -308,35 +308,12 @@ These scripts use the following elements:
 
 # Building
 
-First time only:
-
-    fsiAnyCpu setup\setup.fsx
-
-Then:
-
-    dotnet restore
     dotnet build
     dotnet test
     dotnet pack
 
 
-# Roadmap - Core API
-
-* Port gradient and training/optimization code (from the Scala-Tensorflow)
-
-* Port testing for core API
-
-* GPU execution
-
-* TPU execution
-
-* Add docs
-
 # Roadmap - DSL
-
-* Reuse graphs (deal with shape variables)
-
-* Switch to using ported gradient code when it is available in core API
 
 * Hand-code or generate larger TF surface area in FM DSL
 
@@ -358,7 +335,7 @@ Then:
 
 # Roadmap - Live checking
 
-* Make it into an F# Anaylzer, including adding tooltips to F# analyzer design
+* Make it into an F# Analyzer, including adding tooltips to F# analyzer design
 
 * Make it into a nuget you reference and start live checking from the script
 
@@ -382,6 +359,7 @@ Then:
 
 * Make existing constraints generalizable independently of Extension methods satisfying constraints
 
+* Improve Nullable interop
 
 
 

--- a/examples/ImageClassifier.fsx
+++ b/examples/ImageClassifier.fsx
@@ -1,19 +1,19 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
 #I "../tests/bin/Debug/net472/"
-#r "FSharp.AI.dll"
+#r "FSAI.Tools.dll"
 #r "Tensorflow.NET.dll"
 #r "NumSharp.Core.dll"
-#r "FSharp.AI.Tests.dll"
+#r "FSAI.Tools.Tests.dll"
 #r "System.IO.Compression.dll"
 #r "System.Memory"
 #r "Markeli.Half"
 #nowarn "760" "49"
 
 open Tensorflow
-open FSharp.AI
-open FSharp.AI.Tests.TF
-open FSharp.AI.Tests
+open FSAI.Tools
+open FSAI.Tools.Tests.TF
+open FSAI.Tools.Tests
 open System.IO
 open NumSharp
 

--- a/examples/LinearRegression.fsx
+++ b/examples/LinearRegression.fsx
@@ -1,11 +1,11 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
 #I "../tests/bin/Debug/net472/"
-#r "FSharp.AI.dll"
+#r "FSAI.Tools.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"
 #r "Argu.dll"
-#r "FSharp.AI.Tests.dll"
+#r "FSAI.Tools.Tests.dll"
 
 open System
 open System.IO

--- a/examples/NeuralStyleTransfer-dsl.fsx
+++ b/examples/NeuralStyleTransfer-dsl.fsx
@@ -4,13 +4,13 @@ This example shows the NeuralStyles transfer model using the FM F#-for-AI-models
 
 See [the original python example](https://medium.com/tensorflow/neural-style-transfer-creating-art-with-deep-learning-using-tf-keras-and-eager-execution-7d541ac31398).
 
-Build the Debug 'FSharp.AI.Tests' before using this
+Build the Debug 'FSAI.Tools.Tests' before using this
 *) 
 
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net472/FSharp.AI.dll"
+#r "../tests/bin/Debug/net472/FSAI.Tools.dll"
 #r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
 #r "../tests/bin/Debug/net472/NumSharp.Core.dll"
 
@@ -20,8 +20,8 @@ Preliminaries for F# scripting
 
 open System
 open System.IO
-open FSharp.AI
-open FSharp.AI.DSL
+open FSAI.Tools
+open FSAI.Tools.DSL
 open NPYReaderWriter
 
 (**markdown

--- a/examples/NeuralStyleTransfer.fsx
+++ b/examples/NeuralStyleTransfer.fsx
@@ -1,10 +1,10 @@
 ﻿#I __SOURCE_DIRECTORY__
 #r "netstandard"
 #I "../tests/bin/Debug/net472/"
-#r "FSharp.AI.dll"
+#r "FSAI.Tools.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"
-#r "FSharp.AI.Tests.dll"
+#r "FSAI.Tools.Tests.dll"
 #r "System.Memory.dll"
 #nowarn "25"
 
@@ -13,8 +13,8 @@ open System.IO
 open Tensorflow
 open Tensorflow.Operations
 open NumSharp
-open FSharp.AI.Tests
-open FSharp.AI.ImageWriter
+open FSAI.Tools.Tests
+open FSAI.Tools.ImageWriter
 
 let sess = new Session()
 let weights = Utils.fetchStyleWeights("rain")

--- a/examples/NugetDeployment.fsx
+++ b/examples/NugetDeployment.fsx
@@ -69,7 +69,7 @@ filename=\"%s\"\r\n" filename filename |> toBytes
 #r @"..\lib\Microsoft.Web.XmlTransform.dll"
 #r @"..\lib\NuGet.Core.dll"
 
-let name = "FSharp.AI"
+let name = "FSAI.Tools"
 let version = "0.0.0.1"
 let description = "TensorFlow bindings for F#. Code ported from TensorFlowSharp (C#) and from TensorFlow (python)"
 let releaseNotes = "Alpha"
@@ -82,7 +82,7 @@ let mm = NuGet.ManifestMetadata(
             Description = description,
             Summary = description,
             ReleaseNotes = releaseNotes,
-            ProjectUrl = "https://github.com/fsprojects/FSharp.AI",
+            ProjectUrl = "https://github.com/fsprojects/FSAI.Tools",
             Copyright = "Microsoft and contributors",
             Authors = "Microsoft",
             Owners = "fsprojects, dsyme",
@@ -120,8 +120,8 @@ sprintf @"C:\Users\fsprojects\AppData\Local\Statfactory\FCell\%s"
 let dependecies =  [ ("ionic.zlib","1.9.1.5"); ("HDF.PInvoke.NETStandard","1.10.200"); ("Argu","5.1.0");("Google.Protobuf","3.6.1"); ("protobuf-net","2.4.0")]
 
 [|
-    for file in ["FSharp.AI.dll";"FSharp.AI.XML"; "libtensorflow.dll";
-"FSharp.AI.Proto.dll";"FSharp.AI.Proto.xml"]  ->
+    for file in ["FSAI.Tools.dll";"FSAI.Tools.XML"; "libtensorflow.dll";
+"FSAI.Tools.Proto.dll";"FSAI.Tools.Proto.xml"]  ->
         MPackageFile(file,@"lib\net40\" + file, net40,[|net40|], File.ReadAllBytes(__SOURCE_DIRECTORY__ + sprintf "\\bin\\Debug\\%s"
 file))
 |] |> Seq.iter pb.Files.Add

--- a/examples/TF.MNist.fsx
+++ b/examples/TF.MNist.fsx
@@ -3,10 +3,10 @@
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
 #I "../tests/bin/Debug/net472/"
-#r "FSharp.AI.dll"
+#r "FSAI.Tools.dll"
 #r "TensorFlow.Net.dll"
 #r "NumSharp.Core.dll"
-#r "FSharp.AI.Tests.dll"
+#r "FSAI.Tools.Tests.dll"
 #r "ICSharpCode.SharpZipLib.dll"
 #r "System.IO.Compression.dll"
 #r "System.IO.Compression.FileSystem.dll"
@@ -26,7 +26,7 @@ open System
 open Tensorflow
 open Tensorflow.Operations
 open NumSharp
-open FSharp.AI.Tests.Data
+open FSAI.Tools.Tests.Data
 
 #if FS47
 open Tensorflow.Binding

--- a/examples/TorchSharp.MNist.fsx
+++ b/examples/TorchSharp.MNist.fsx
@@ -9,7 +9,7 @@
 #r "netstandard"
 #I "../tests/bin/Debug/net472/"
 #r "TorchSharp.dll"
-#r "FSharp.AI.Tests.dll"
+#r "FSAI.Tools.Tests.dll"
 
 open TorchSharp
 open TorchSharp.Tensor

--- a/examples/dsl-live.fsx
+++ b/examples/dsl-live.fsx
@@ -1,16 +1,16 @@
-﻿// Build the Debug 'FSharp.AI.Tests' before using this
+﻿// Build the Debug 'FSAI.Tools.Tests' before using this
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net472/FSharp.AI.dll"
+#r "../tests/bin/Debug/net472/FSAI.Tools.dll"
 #r "../tests/bin/Debug/net472/NumSharp.Core.dll"
 #r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
 #r "FSharp.Compiler.Interactive.Settings"
 #nowarn "49"
 
 open System
-open FSharp.AI
-open FSharp.AI.DSL
+open FSAI.Tools
+open FSAI.Tools.DSL
 open Microsoft.FSharp.Compiler.Interactive.Settings
 
 if not System.Environment.Is64BitProcess then System.Environment.Exit(-1)

--- a/src/FSAI.Tools/FM.fs
+++ b/src/FSAI.Tools/FM.fs
@@ -1,4 +1,4 @@
-namespace FSharp.AI.DSL
+namespace FSAI.Tools.DSL
 
 open System
 open System.Reflection
@@ -7,7 +7,7 @@ open Tensorflow
 open NumSharp
 open System.Numerics
 open System.Runtime.InteropServices
-open FSharp.AI.NNImpl
+open FSAI.Tools.NNImpl
 
 #if FS47
 open Tensorflow.Binding
@@ -1792,7 +1792,7 @@ module DT =
 (*
     // NOTE: not supported on TensorFlow due to use of C++ AddGradients only supporting
     // first-order differentials 
-    // Message: FSharp.AI.TFException: No gradient defined for op: OnesLike. 
+    // Message: FSAI.Tools.TFException: No gradient defined for op: OnesLike. 
 
     /// Hessian of a vector-to-scalar function `f`, at point `x`. Forward-on-reverse AD.
     let hessian (f: DT<'T> -> Scalars<'T>) x: Matrices<'T> =

--- a/src/FSAI.Tools/FSAI.Tools.fsproj
+++ b/src/FSAI.Tools/FSAI.Tools.fsproj
@@ -3,11 +3,10 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>TensorFlow</RootNamespace>
-    <AssemblyName>FSharp.AI</AssemblyName>
+    <RootNamespace>FSAI.Tools</RootNamespace>
+    <AssemblyName>FSAI.Tools</AssemblyName>
     <ReleaseVersion>0.1</ReleaseVersion>
-    <TensorFlowRuntimeVersion>1.11.0</TensorFlowRuntimeVersion>
-    <NuspecFile>build\FSharp.AI.nuspec</NuspecFile>
+    <NuspecFile>build\FSAI.Tools.nuspec</NuspecFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
@@ -16,11 +15,8 @@
     <PackageReference Include="NumSharp" Version="0.20.0" />
     <PackageReference Include="Markeli.Half" Version="1.0.0" />
     <PackageReference Include="Ionic.Zlib.Core" Version="1.0.0" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
     <PackageReference Include="TensorFlow.NET" Version="0.11.0" />
     <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,14 +25,6 @@
     <Compile Include="NPYReaderWriter.fs" /> 
     <Compile Include="ImageWriter.fs" />
     <Compile Include="FM.fs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="$(NuGetPackageRoot)scisharp.tensorflow.redist\1.14.0\runtimes\win-x64\native\*.dll" Condition="'$(PlatformTarget)' == 'x64'">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-      <Link>%(Filename)%(Extension)</Link>
-    </Content>
   </ItemGroup>
 
 </Project>

--- a/src/FSAI.Tools/ImageWriter.fs
+++ b/src/FSAI.Tools/ImageWriter.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.ImageWriter
+﻿module FSAI.Tools.ImageWriter
 
 // This is a lightweight library for saving bitmap files in order to view the output of image base machine learning
 // The point of this is is have minimal dependencies for examples

--- a/src/FSAI.Tools/NPYReaderWriter.fs
+++ b/src/FSAI.Tools/NPYReaderWriter.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.NPYReaderWriter
+﻿module FSAI.Tools.NPYReaderWriter
 
 open System
 open System.IO

--- a/src/FSAI.Tools/Operations.ArrayGrad.fs
+++ b/src/FSAI.Tools/Operations.ArrayGrad.fs
@@ -1,0 +1,2 @@
+﻿module FSAI.Tools.Operations.ArrayGrad
+

--- a/src/FSAI.Tools/Operations.Extras.fs
+++ b/src/FSAI.Tools/Operations.Extras.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module FSharp.AI.OperationExtras
+module FSAI.Tools.OperationExtras
 
 open System
 

--- a/src/FSAI.Tools/Operations.NN.fs
+++ b/src/FSAI.Tools/Operations.NN.fs
@@ -1,5 +1,5 @@
 ﻿[<AutoOpen>]
-module FSharp.AI.NNImpl
+module FSAI.Tools.NNImpl
 
 open Tensorflow
 open Tensorflow.Operations
@@ -32,7 +32,7 @@ type gen_ops with
         let data_formatV = defaultArg data_format "NHWC"
         let name = defaultArg name "conv2d_transpose"
         // TODO re-do Dimension and Shape functions 
-        // https://github.com/fsprojects/FSharp.AI/blob/cdbd841bc86136f8ef24524cfc346e77bf21e6af/src/FSharp.AI/Tensorflow.fs#L409
+        // https://github.com/fsprojects/FSAI.Tools/blob/cdbd841bc86136f8ef24524cfc346e77bf21e6af/src/FSAI.Tools/Tensorflow.fs#L409
 //        if not (data_formatV = "NCHW" || data_formatV = "NHWC") then 
 //            failwith "dataformat has to be either NCHW or NHWC."
 //        let axis = if data_formatV = "NHWC" then 3 else 1

--- a/src/FSAI.Tools/Utils.fs
+++ b/src/FSAI.Tools/Utils.fs
@@ -1,5 +1,5 @@
 [<AutoOpen>]
-module FSharp.AI.Utils
+module FSAI.Tools.Utils
 open System
 open System.Collections
 open System.Collections.Generic

--- a/src/FSAI.Tools/build/FSAI.Tools.nuspec
+++ b/src/FSAI.Tools/build/FSAI.Tools.nuspec
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
-    <id>FSharp.AI</id>
+    <id>FSAI.Tools</id>
     <version>1.11.0-pre1</version>
-    <title>FSharp.AI</title>
+    <title>FSAI.Tools</title>
     <!-- TODO add more authors owners etc. e.g. Don Syme and Miguel de Icaza -->
     <authors>Matthew Moloney</authors>
     <owners>Matthew Moloney</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <!-- a weird error in licence <license>MIT</license> -->
-    <licenseUrl>https://github.com/fsprojects/FSharp.AI/Licence</licenseUrl>
-    <projectUrl>https://github.com/fsprojects/FSharp.AI/</projectUrl>
+    <licenseUrl>https://github.com/fsprojects/FSAI.Tools/Licence</licenseUrl>
+    <projectUrl>https://github.com/fsprojects/FSAI.Tools/</projectUrl>
     <!--<iconUrl></iconUrl>-->
-    <repository type="git" url=" https://github.com/fsprojects/FSharp.AI/" />
+    <repository type="git" url=" https://github.com/fsprojects/FSAI.Tools/" />
     <description>F# .NET Bindings for TensorFlow</description>
     <summary>F# .NET API for TensorFlow, Google's Machine Intelligence framework</summary>
     <releaseNotes>1.11.0 adds support for the TensorFlow 1.11 release</releaseNotes>
@@ -28,16 +28,16 @@
       <dependency id="System.Runtime.InteropServices" version="4.3.0" />
     </dependencies>
     <references>
-      <reference file="FSharp.AI.Proto.dll" />
-      <reference file="FSharp.AI.dll" />
+      <reference file="FSAI.Tools.Proto.dll" />
+      <reference file="FSAI.Tools.dll" />
     </references>
   </metadata>
   <files>
-    <file src="..\..\..\lib\FSharp.AI.Proto.dll" target="lib\netstandard2.0\FSharp.AI.Proto.dll" />
+    <file src="..\..\..\lib\FSAI.Tools.Proto.dll" target="lib\netstandard2.0\FSAI.Tools.Proto.dll" />
     <!-- NOTE: should we use Debug instead of Release? -->
-    <file src="..\bin\Release\netstandard2.0\FSharp.AI.dll" target="lib\netstandard2.0\FSharp.AI.dll" />
-    <file src="..\bin\Release\netstandard2.0\FSharp.AI.xml" target="lib\netstandard2.0\FSharp.AI.xml" />
-    <file src="..\..\..\lib\FSharp.AI.Proto.dll" target="lib\netstandard2.0\FSharp.AI.Proto.dll" />
+    <file src="..\bin\Release\netstandard2.0\FSAI.Tools.dll" target="lib\netstandard2.0\FSAI.Tools.dll" />
+    <file src="..\bin\Release\netstandard2.0\FSAI.Tools.xml" target="lib\netstandard2.0\FSAI.Tools.xml" />
+    <file src="..\..\..\lib\FSAI.Tools.Proto.dll" target="lib\netstandard2.0\FSAI.Tools.Proto.dll" />
     <file src="..\..\..\lib\libtensorflow.dll" target="lib\netstandard2.0\libtensorflow.dll" />
     <file src="..\..\..\lib\libtensorflow.dylib" target="lib\netstandard2.0\libtensorflow.dylib" />
     <file src="..\..\..\lib\libtensorflow_framework.dylib" target="lib\netstandard2.0\libtensorflow_framework.dylib" />

--- a/src/FSharp.AI/Operations.ArrayGrad.fs
+++ b/src/FSharp.AI/Operations.ArrayGrad.fs
@@ -1,2 +1,0 @@
-﻿module FSharp.AI.Operations.ArrayGrad
-

--- a/tests/DSL.Tests.fs
+++ b/tests/DSL.Tests.fs
@@ -1,12 +1,12 @@
-// Build the Debug 'FSharp.AI.Tests' before using this
+// Build the Debug 'FSAI.Tools.Tests' before using this
 
 module FM.Tests
 
 open NUnit.Framework
 
 open System
-open FSharp.AI
-open FSharp.AI.DSL
+open FSAI.Tools
+open FSAI.Tools.DSL
 
 [<Test>]
 let check64() = 

--- a/tests/DSL.VGGStyleTransfer.fs
+++ b/tests/DSL.VGGStyleTransfer.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.VGGStyleTransferDSL
+﻿module FSAI.Tools.VGGStyleTransferDSL
 
 // NOTE: Most operations were converted from double (float) to single as that is how this model was designed
 // NOTE: I'm unsure why the shape resolver is not working 
@@ -7,11 +7,11 @@
 //
 // See https://medium.com/tensorflow/neural-style-transfer-creating-art-with-deep-learning-using-tf-keras-and-eager-execution-7d541ac31398
 //
-// Build the Debug 'FSharp.AI.Tests' before using this
+// Build the Debug 'FSAI.Tools.Tests' before using this
 
 //#I __SOURCE_DIRECTORY__
 //#r "netstandard"
-//#r "../tests/bin/Debug/net472/FSharp.AI.dll"
+//#r "../tests/bin/Debug/net472/FSAI.Tools.dll"
 //#r "../tests/bin/Debug/net472/Tensorflow.Net.dll"
 //#r "../tests/bin/Debug/net472/NumSharp.Core.dll"
 //#load "shared/NPYReaderWriter.fsx"
@@ -23,8 +23,8 @@
 
 open System
 open System.IO
-open FSharp.AI
-open FSharp.AI.DSL
+open FSAI.Tools
+open FSAI.Tools.DSL
 open NPYReaderWriter
 
 

--- a/tests/Data.MNist.fs
+++ b/tests/Data.MNist.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.Tests.Data.MNist
+﻿module FSAI.Tools.Tests.Data.MNist
 
 open NumSharp
 open System

--- a/tests/FSAI.Tools.Tests.fsproj
+++ b/tests/FSAI.Tools.Tests.fsproj
@@ -4,8 +4,8 @@
     <OutputType>Library</OutputType>
     <TargetFrameworks>netcoreapp2.0;net472</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;osx-x86;linux-x64</RuntimeIdentifiers>
-    <RootNamespace>FSharp.AI.Tests</RootNamespace>
-    <AssemblyName>FSharp.AI.Tests</AssemblyName>
+    <RootNamespace>FSAI.Tools.Tests</RootNamespace>
+    <AssemblyName>FSAI.Tools.Tests</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibTorch.Redist" Version="0.2.0-preview-27915-4" />
-    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.0" />
+    <PackageReference Include="SciSharp.TensorFlow.Redist" Version="1.14.1" />
     <PackageReference Include="SharpZipLib" Version="1.1.0" />
     <PackageReference Include="Torch.NET" Version="3.7.1.1" />
     <PackageReference Include="TorchSharp" Version="0.2.0-preview-27915-4" />
@@ -58,7 +58,7 @@
    
   </Target>
  <ItemGroup>
-    <ProjectReference Include="..\src\FSharp.AI\FSharp.AI.fsproj" />
+    <ProjectReference Include="..\src\FSAI.Tools\FSAI.Tools.fsproj" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">

--- a/tests/ResNet50TensorFlowNet.fs
+++ b/tests/ResNet50TensorFlowNet.fs
@@ -1,5 +1,5 @@
 ﻿module ResNet50TensorFlowNet
-//open FSharp.AI
+//open FSAI.Tools
 open System
 open Tensorflow
 type ops = Tensorflow.Operations.gen_ops

--- a/tests/TF.ResNet50Classifier.fs
+++ b/tests/TF.ResNet50Classifier.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.Tests.TF.ResNet50Classifier
+﻿module FSAI.Tools.Tests.TF.ResNet50Classifier
 
 open Tensorflow
 open Tensorflow.Operations

--- a/tests/TF.Tests.fs
+++ b/tests/TF.Tests.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.Tests.TF.Tests
+﻿module FSAI.Tools.Tests.TF.Tests
 
 open NUnit.Framework
 
@@ -7,7 +7,7 @@ open System.IO
 open Tensorflow
 open Tensorflow.Operations
 open NumSharp
-open FSharp.AI.Tests
+open FSAI.Tools.Tests
 
 #if FS47
 open Tensorflow.Binding

--- a/tests/TF.VGGStyleTransfer.fs
+++ b/tests/TF.VGGStyleTransfer.fs
@@ -1,4 +1,4 @@
-﻿module FSharp.AI.Tests.TF.VGGStyleTransfer
+﻿module FSAI.Tools.Tests.TF.VGGStyleTransfer
 
 open System
 open Tensorflow

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -3,8 +3,8 @@
 //
 //
 //open NUnit.Framework
-//open FSharp.AI
-//open FSharp.AI.Operations
+//open FSAI.Tools
+//open FSAI.Tools.Operations
 //open System.Runtime.CompilerServices
 //open System
 //open System.IO

--- a/tests/Utils.fs
+++ b/tests/Utils.fs
@@ -1,10 +1,10 @@
-﻿module FSharp.AI.Tests.Utils
+﻿module FSAI.Tools.Tests.Utils
 
 open Tensorflow
-open FSharp.AI
+open FSAI.Tools
 open System.IO
 open Tensorflow.Operations
-open FSharp.AI.NPYReaderWriter
+open FSAI.Tools.NPYReaderWriter
 
 #if FS47
 open Tensorflow.Binding

--- a/tests/api-tests.fsx
+++ b/tests/api-tests.fsx
@@ -1,15 +1,15 @@
-// Build the Debug 'FSharp.AI.Tests' before using this
+// Build the Debug 'FSAI.Tools.Tests' before using this
 
 #I __SOURCE_DIRECTORY__
 #r "netstandard"
-#r "../tests/bin/Debug/net472/FSharp.AI.Proto.dll"
-#r "bin/Debug/net472/FSharp.AI.dll"
+#r "../tests/bin/Debug/net472/FSAI.Tools.Proto.dll"
+#r "bin/Debug/net472/FSAI.Tools.dll"
 #nowarn "49"
 
 //open Argu
 open System
 open System.IO
-open FSharp.AI
+open FSAI.Tools
 
 if not System.Environment.Is64BitProcess then System.Environment.Exit(-1)
 


### PR DESCRIPTION
Renaming to avoid squatting the `FSharp.AI` namespace